### PR TITLE
obtain pyload 0.4.10 from github

### DIFF
--- a/pyload/Makefile
+++ b/pyload/Makefile
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2011 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=pyload
+PKG_VERSION:=0.4.10
+PKG_RELEASE:=1
+
+PKG_REV:=$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+PKG_SOURCE_URL:=git://github.com/pyload/pyload.git
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/pyload
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+python +pyopenssl +python-curl +python-crypto +python-django \
+	+python-expat +python-imaging-library +python-sqlite3 +js \
+	+tesseract +unrar
+  TITLE:=A fast, lightweight and full featured download manager
+  URL:=http://pyload.org
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)/pyload
+	tar xvfj $(DL_DIR)/$(PKG_SOURCE)
+	$(CP) ./$(PKG_NAME)-$(PKG_VERSION)/* $(PKG_BUILD_DIR)/pyload
+	chmod +x $(PKG_BUILD_DIR)/pyload/*.py
+	rm -rf ./$(PKG_NAME)-$(PKG_VERSION)*
+endef
+
+define Build/Compile
+endef
+
+define Package/pyload/install
+	$(INSTALL_DIR) $(1)/opt/share/python
+	$(CP) $(PKG_BUILD_DIR)/pyload $(1)/opt/share/python/
+	$(INSTALL_DIR) $(1)/opt/bin
+	$(LN) ../share/python/pyload/pyload.py $(1)/opt/bin/pyload
+	$(INSTALL_DIR) $(1)/opt/etc/init.d
+	$(INSTALL_BIN) ./files/S51pyload $(1)/opt/etc/init.d
+endef
+
+$(eval $(call BuildPackage,pyload))

--- a/pyload/files/S51pyload
+++ b/pyload/files/S51pyload
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+prefix="/opt"
+PATH=${prefix}/bin:${prefix}/sbin:/sbin:/bin:/usr/sbin:/usr/bin
+
+start() {
+	echo "starting pyLoad"
+	pyload --daemon
+	}
+
+stop() {
+	echo "stopping pyLoad"
+	pyload --status | xargs kill -9
+	}
+
+status() {
+	pyload --status
+	}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	restart)
+		stop
+		sleep 4
+		start
+		;;
+	status) status
+		;;
+	*)
+		echo "Usage: $0 (start|stop|restart|status)"
+		exit 1
+		;;
+esac
+
+exit 0


### PR DESCRIPTION
Hi,
I rewrote the OpenWRT makefile to make sure pyloads source is fetched from github. A change in the Start-Stop-Script was needed due to refactoring in pyloads code.

0.4.10 runs well beside a jinja2 warning in the setup, which can be ignored when using threaded WebIF.
An ipk for a quick try is at https://www.dropbox.com/s/43udmrf2cvs2u9v/pyload_0.4.10-1_entware.ipk

greets !gm
